### PR TITLE
Clear avatar emoji cache on update

### DIFF
--- a/app/lib/friends/profile_emoji/account_extension.rb
+++ b/app/lib/friends/profile_emoji/account_extension.rb
@@ -3,12 +3,22 @@ module Friends
     module AccountExtension
       extend ActiveSupport::Concern
 
+      included do
+        after_commit :clear_avatar_cache
+      end
+
       def profile_emojis
         @profile_emojis ||= Friends::ProfileEmoji::Emoji.from_text(emojifiable_text)
       end
 
       def all_emojis
         emojis + profile_emojis
+      end
+
+      private
+
+      def clear_avatar_cache
+        EntityCache.instance.clear_avatar(username, domain)
       end
     end
   end

--- a/app/lib/friends/profile_emoji/entity_cache_extension.rb
+++ b/app/lib/friends/profile_emoji/entity_cache_extension.rb
@@ -6,6 +6,10 @@ module Friends
       def avatar(username, domain)
         Rails.cache.fetch(to_key(:avatar, username, domain), expires_in: EntityCache::MAX_EXPIRATION) { Account.select(:id, :username, :domain, :avatar_file_name).find_remote(username, domain) }
       end
+
+      def clear_avatar(username, domain)
+        Rails.cache.delete(to_key(:avatar, username, domain))
+      end
     end
   end
 end


### PR DESCRIPTION
プロフィール画像更新時に適切に画像が切り替わらない問題に対処