### PR TITLE
ライトテーマでのお知らせの配色をいい感じに

### DIFF
--- a/app/javascript/styles/mastodon-light/diff-best-friends.scss
+++ b/app/javascript/styles/mastodon-light/diff-best-friends.scss
@@ -13,3 +13,9 @@
     }
   }
 }
+
+.compose__extra__header {
+  &__icon {
+    color: $black;
+  }
+}

--- a/app/javascript/styles/mastodon-light/diff-best-friends.scss
+++ b/app/javascript/styles/mastodon-light/diff-best-friends.scss
@@ -1,0 +1,15 @@
+.announcements {
+  li {
+    border: solid 1px lighten($ui-base-color, 8%);
+  }
+  
+  .announcements__body {
+    color: $lighter-text-color;
+    .links {
+      a {
+        border-color: $lighter-text-color;
+        color: $lighter-text-color;
+      }
+    }
+  }
+}

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -1,7 +1,7 @@
 // Notes!
 // Sass color functions, "darken" and "lighten" are automatically replaced.
 
-@import "diff-best-friends.scss";
+@import 'diff-best-friends.scss';
 
 html {
   scrollbar-color: $ui-base-color rgba($ui-base-color, 0.25);

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -1,6 +1,8 @@
 // Notes!
 // Sass color functions, "darken" and "lighten" are automatically replaced.
 
+@import "diff-best-friends.scss";
+
 html {
   scrollbar-color: $ui-base-color rgba($ui-base-color, 0.25);
 }


### PR DESCRIPTION
| before (今のbest-friends.chat) | after |
|---|---|
|![image](https://user-images.githubusercontent.com/6533808/69199926-f0ade580-0b7c-11ea-9e03-5c5c92bcd809.png)|![image](https://user-images.githubusercontent.com/6533808/69199933-f7d4f380-0b7c-11ea-8dad-bbc95c1369b3.png)|

懸念: mastodon-lightの下にdiff-best-friends.scssを置くのではなくてbest-friendsの下にdiff-light.scss的なのを置くほうがよい?